### PR TITLE
Throw TypeError when input isn't a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = (function (array) {
   return function luhn (number) {
+    if (typeof number !== 'string') throw new TypeError('Expected string input')
     if (!number) return false
     var length = number.length
     var bit = 1


### PR DESCRIPTION
This prevents a pretty common error when giving the function a number would always return `false`. This is especially confusing since the parameter in question is named `number`.