### PR TITLE
Fix exception when receiving an undefined value

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 module.exports = (function (array) {
   return function luhn (number) {
-    if (typeof number !== 'string') throw new TypeError('Expected string input')
     if (!number) return false
+    if (typeof number !== 'string') throw new TypeError('Expected string input')
     var length = number.length
     var bit = 1
     var sum = 0

--- a/test.js
+++ b/test.js
@@ -9,5 +9,6 @@ test(function (t) {
   t.equal(luhn(''), false, 'falsy')
   t.equal(luhn(undefined), false, 'falsy')
   t.equal(luhn(null), false, 'falsy')
+  t.throws(function () { luhn(12345) }, /TypeError/, 'invalid type')
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -7,5 +7,7 @@ test(function (t) {
   t.ok(luhn('4242424242424242'), 'passing')
   t.notOk(luhn('4242424242424241'), 'failing')
   t.equal(luhn(''), false, 'falsy')
+  t.equal(luhn(undefined), false, 'falsy')
+  t.equal(luhn(null), false, 'falsy')
   t.end()
 })


### PR DESCRIPTION
**Fixing BC-break caused by #5**

The exception added on #5 should be thrown after we validade that `number` **isn't** `empty`, `null` or `undefined` (untested scenario).

Receiving an `undefined` value wasn't an expected scenario (accordingly to tests) yet was been supported, therefore merging #5 caused a BC-break. This PR aims to fix this BC-break keeping all expected behaviour and adding missing tests.