### PR TITLE
fixing an issue where any number consisting of all zeros failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,6 @@ module.exports = (function (array) {
       sum += bit ? array[value] : value
     }
 
-    return !!sum && sum % 10 === 0
+    return sum % 10 === 0
   }
 }([0, 2, 4, 6, 8, 1, 3, 5, 7, 9]))

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ var luhn = require('./')
 
 test(function (t) {
   t.ok(luhn('4242424242424242'), 'passing')
+  t.ok(luhn('0000000000000000'), 'passing')
   t.notOk(luhn('4242424242424241'), 'failing')
   t.equal(luhn(''), false, 'falsy')
   t.end()


### PR DESCRIPTION
A number that is all zeros should always pass a luhn check.  `!!sum` was causing such numbers to fail.  I'm assuming that check was added before the initial checks on the value given and can be safely removed now.