### PR TITLE
Convert package to ESM

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,1 @@
-declare const luhn: (pan: string) => boolean;
-export default luhn;
+export default function luhn (pan: string): boolean;

--- a/index.js
+++ b/index.js
@@ -1,20 +1,18 @@
-'use strict'
+const array = [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]
 
-module.exports = (function (array) {
-  return function luhn (number) {
-    if (typeof number !== 'string') throw new TypeError('Expected string input')
-    if (!number) return false
-    let length = number.length
-    let bit = 1
-    let sum = 0
-    let value
+export default function luhn (number) {
+  if (typeof number !== 'string') throw new TypeError('Expected string input')
+  if (!number) return false
+  let length = number.length
+  let bit = 1
+  let sum = 0
+  let value
 
-    while (length) {
-      value = parseInt(number.charAt(--length), 10)
-      bit ^= 1
-      sum += bit ? array[value] : value
-    }
-
-    return sum % 10 === 0
+  while (length) {
+    value = parseInt(number.charAt(--length), 10)
+    bit ^= 1
+    sum += bit ? array[value] : value
   }
-}([0, 2, 4, 6, 8, 1, 3, 5, 7, 9]))
+
+  return sum % 10 === 0
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "fast-luhn",
   "version": "2.0.0",
   "description": "A fast Luhn algorithm for validating credit cards",
-  "main": "index.js",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "test": "standard && tape test.js"
   },
@@ -33,6 +34,6 @@
     "*.ts"
   ],
   "engines": {
-    "node": ">=8"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const test = require('tape')
-const luhn = require('./')
+import test from 'tape'
+import luhn from './index.js'
 
 test(function (t) {
   t.ok(luhn('4242424242424242'), 'passing')


### PR DESCRIPTION
Hello,

I know this might be a controversial change, so sorry for not opening up an issue to discuss this first. This package is currently incompatible with `"moduleResolution": "node16"` in TypeScript 4.7+ so I wanted to fix this in my fork to unblock myself.

Currently the TypeScript typings use ESM style `export default`, but the actual package uses `module.exports =`. Another fix for this could be to change the typings to `export =`, but that can have some problems with some bundlers as far as I'm aware...

Since there isn't much churn on this package I figured that making a breaking change and keeping the 2.x version around whilst people move to ESM would be fine.

Here is some more information about switching packages over to ESM: https://github.com/sindresorhus/meta/discussions/15

Happy to discuss ways forward here!