### PR TITLE
Update typings to match source export statement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 declare const luhn: (pan: string) => boolean;
-export default luhn;
+export = luhn;


### PR DESCRIPTION
This is an alternative to #31, and is what I'm currently using locally with `patch-package` to get compiling working.

_Potentially,_ this is a breaking change to some consumers, but I'm not sure what specific cases it would break.

I'd argue that this is the _correct_ typings since this reflects what is written in the JavaScript source code (`module.exports = ...`)